### PR TITLE
fix(markers-display): src without marker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cassettator.js",
-  "version": "0.69.420",
+  "version": "0.69.42035",
   "description": "A collection of video.js components and plugins",
   "author": "amtins <amtins.dev@gmail.com>",
   "license": "MIT",

--- a/src/browser.js
+++ b/src/browser.js
@@ -1,7 +1,0 @@
-// MEH... 😒
-
-import videojs from 'video.js';
-import CassettatorMarkers from './markers/src/cassettator-markers-plugin.js';
-
-window.videojs = videojs;
-window.CassettatorMarkers = CassettatorMarkers;

--- a/src/markers/src/markers-display.js
+++ b/src/markers/src/markers-display.js
@@ -75,8 +75,9 @@ class MarkersDisplay extends videojs.getComponent('component') {
     );
 
     if (!markersTrack) {
-      this.addChild('marker', {
+      this.addChild('marker-empty', {
         className: 'marker-empty',
+        componentClass: 'markerDisplay',
         startTime: 0,
         endTime: this.player().duration(),
       });


### PR DESCRIPTION
## Description
When loading a source that did not contain a marker, the `loadMarkers` function threw an error because it was trying to add a component that did not exist.
## Changes made


- rename child component name
- deletes `browser.js` which is no longer required
- update `package` verion

