### PR TITLE
feat(markers-display): displays the marker buffer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cassettator.js",
-  "version": "0.69.420",
+  "version": "0.504.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cassettator.js",
-      "version": "0.69.420",
+      "version": "0.504.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-json": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cassettator.js",
-  "version": "0.420.0",
+  "version": "0.504.0",
   "description": "A collection of video.js components and plugins",
   "author": "amtins <amtins.dev@gmail.com>",
   "license": "MIT",

--- a/src/markers/css/cassettator-markers.css
+++ b/src/markers/css/cassettator-markers.css
@@ -3,7 +3,7 @@
   /* private variables */
   --_cst-marker-played: 0%;
   /* TODO implement buffered */
-  --cst-marker-buffered: 0%;
+  --_cst-marker-buffered: 0%;
 }
 
 .cassettator-markers .vjs-time-tooltip {
@@ -36,7 +36,7 @@
   height: 100%;
   background: linear-gradient(to right,
       var(--cst-marker-played-background-color, #fff) var(--_cst-marker-played),
-      var(--cst-marker-buffered-background-color, transparent) 0 var(--cst-marker-buffered),
+      var(--cst-marker-buffered-background-color, rgba(115, 133, 159, 0.7)) 0 var(--_cst-marker-buffered),
       var(--cst-marker-background-color, var(--cst-default-background-color)) 0%);
   border-radius: var(--cst-marker-border-radius, 0.05em);
 }


### PR DESCRIPTION
## Description

This feature modifies the `MarkerDisplay` class to add support for displaying and updating the marker buffer at every progress event.

[Screencast from 01-13-24 16:46:24.webm](https://github.com/amtins/cassettator.js/assets/34163393/9df4dedf-eb5c-483d-b700-d2146790c6b8)

## Changes made

- modifies the `updateMarker` function to take a `time` and a `css variable` as parameters
- adds the `updateMarkerBuffered` function, which uses `updateMarker` to update the marker buffer
- adds the `updateMarkerPlayed` function, which uses `updateMarker` to update the played marker
- renames the `css variable` used to update the marker's buffering percentage
- redefines the default color of `--cst-marker-buffered-background-color`

