### PR TITLE
fix(marker-display): error when changing resource

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cassettator.js",
-  "version": "0.504.0",
+  "version": "0.504.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cassettator.js",
-      "version": "0.504.0",
+      "version": "0.504.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-json": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cassettator.js",
-  "version": "0.504.0",
+  "version": "0.504.1",
   "description": "A collection of video.js components and plugins",
   "author": "amtins <amtins.dev@gmail.com>",
   "license": "MIT",

--- a/src/markers/src/marker-display.js
+++ b/src/markers/src/marker-display.js
@@ -68,6 +68,8 @@ class MarkerDisplay extends videojs.getComponent('component') {
    * @param {string} cssVar - The CSS variable name.
    */
   updateMarker(time = 0, cssVar) {
+    if(!this.parentComponent_.el().getClientRects().length) return;
+
     const duration = this.player().duration();
     const markersElWidth = this.parentComponent_.el().getClientRects()[0].width;
     const markerOffsetLeft = this.el().offsetLeft;


### PR DESCRIPTION
## Description

Fix #12 which occurred when loading resource after starting playback. This bug didn't cause any component malfunctions, apart from displaying errors in the console.

## Changes made

- adds a guard clause to `updateMarker` to update the marker only if `getClientRects` is not empty

