### PR TITLE
chore(markers): update demo media URL

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cassettator.js",
-  "version": "0.504.3",
+  "version": "0.504.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cassettator.js",
-      "version": "0.504.3",
+      "version": "0.504.4",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-json": "^6.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cassettator.js",
-  "version": "0.504.3",
+  "version": "0.504.4",
   "description": "A collection of video.js components and plugins",
   "author": "amtins <amtins.dev@gmail.com>",
   "license": "MIT",

--- a/src/markers/index.html
+++ b/src/markers/index.html
@@ -35,7 +35,7 @@
       });
 
       player.src({
-        src: 'https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_16x9/bipbop_16x9_variant.m3u8',
+        src: 'https://d2zihajmogu5jn.cloudfront.net/bipbop-advanced/bipbop_16x9_variant.m3u8',
         type: 'application/x-mpegURL',
         markers: [
           { startTime: 69, label: 'Marker st 69' },


### PR DESCRIPTION
## Description

Updates the URL of the `cassettator-markers` demo media. The CORS rules of the previously used media have changed, causing a playback error.

## Changes made

- uses another URL for bipbop

